### PR TITLE
Anon components

### DIFF
--- a/domchanger.js
+++ b/domchanger.js
@@ -43,7 +43,7 @@ function createComponent(component, parent, owner) {
   var refs = {};
   var data = [];
   var roots = {};
-  // console.log("new " + component.name);
+  // console.log("new " + (component.name || component.fnName));
   var out = component(emit, refresh, refs);
   var render = out.render;
   var on = out.on || {};
@@ -57,7 +57,7 @@ function createComponent(component, parent, owner) {
   };
 
   // Add comment for this component.
-  var comment = document.createComment(component.name);
+  var comment = document.createComment(component.name || component.fnName);
   parent.appendChild(comment);
 
   return instance;
@@ -285,7 +285,7 @@ function nameNodes(raw) {
 
     // Find a unique name for this local namespace.
     var i = 1;
-    var subType = type == "element" ? tag.name : type == "component" ? item[0].name : type;
+    var subType = type == "element" ? tag.name : type == "component" ? item[0].name || item[0].fnName : type;
     var id = type === "element" ? tag.ref : type === "component" ? item.key : null;
     var newPath = id ? subType + "-" + id : subType;
     while (nodes[newPath]) newPath = subType + "-" + (id || "") + (++i);

--- a/domchanger.js
+++ b/domchanger.js
@@ -259,7 +259,6 @@ function nameNodes(raw) {
       type = "text";
     }
     else if (Array.isArray(item)) {
-      if (!item.length) return;
       first = item[0];
       if (typeof first === "function") {
         type = "component";
@@ -346,6 +345,9 @@ function processTag(array) {
   }
   else {
     body = array.slice(1);
+  }
+  if (Array.isArray(body[0]) && !body[0].length) {
+    body[0] = "";
   }
   var string = array[0];
   var name = string.match(TAG_MATCH);

--- a/domchanger.js
+++ b/domchanger.js
@@ -286,7 +286,7 @@ function nameNodes(raw) {
     // Find a unique name for this local namespace.
     var i = 1;
     var subType = type == "element" ? tag.name : type == "component" ? item[0].name || item[0].fnName : type;
-    var id = type === "element" ? tag.ref : type === "component" ? item.key : null;
+    var id = type === "element" ? tag.ref : type === "component" ? item.key || item[0].key : null;
     var newPath = id ? subType + "-" + id : subType;
     while (nodes[newPath]) newPath = subType + "-" + (id || "") + (++i);
 


### PR DESCRIPTION
This changeset enables component constructors to be anonymous funcs and unique component keys to be fixated outside of the parent's `.render()`.

see #5.
