### PR TITLE
handle empty child arrays instead of bailing

### DIFF
--- a/domchanger.js
+++ b/domchanger.js
@@ -259,7 +259,6 @@ function nameNodes(raw) {
       type = "text";
     }
     else if (Array.isArray(item)) {
-      if (!item.length) return;
       first = item[0];
       if (typeof first === "function") {
         type = "component";
@@ -346,6 +345,9 @@ function processTag(array) {
   }
   else {
     body = array.slice(1);
+  }
+  if (Array.isArray(body[0]) && !body[0].length) {
+    body[0] = "";
   }
   var string = array[0];
   var name = string.match(TAG_MATCH);


### PR DESCRIPTION
Found a bug where the `FilterableProductTable` example does not update when the entered filters result in 0 matches, so an empty child array. `domChanger` bails here at the next level [1], but shouldn't. This removes the bailout and updates `processTag()` to convert empty child arrays to empty strings.

This change is also merged into my https://github.com/leeoniya/domchanger/tree/anon-components branch.

[1] https://github.com/creationix/domchanger/blob/master/domchanger.js#L262
